### PR TITLE
AlertType→AlertVariant 마이그레이션

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -4,7 +4,7 @@ import { Router } from '@iyulab/router';
 import { setDefaultBaseUrl } from '@iyulab/components/dist/utilities/IconRegistry.js';
 import { Theme } from '@iyulab/components/dist/utilities/Theme.js';
 import { Notifier } from '@iyulab/components/dist/utilities/Notifier.js';
-import type { AlertType } from '@iyulab/components/dist/components/alert/UAlert.component.js';
+import type { AlertVariant } from '@iyulab/components/dist/components/alert/UAlert.component.js';
 
 import { ScreenObserver, type ScreenSize } from './internals/ScreenObserver';
 import type { AppConfig, LayoutConfig } from './types/AppConfigs';
@@ -158,9 +158,9 @@ class App {
   }
 
   /** 알림 표시 */
-  private async notify(type: AlertType, message: string, options?: NotificationOptions): Promise<void> {
+  private async notify(variant: AlertVariant, message: string, options?: NotificationOptions): Promise<void> {
     await Notifier.toast({
-      type: type,
+      variant: variant,
       content: message,
       heading: options?.title,
       duration: options?.duration || 3000,


### PR DESCRIPTION
## 요약

`@iyulab/components` v0.5.0의 breaking change에 대응하여 `App.ts`의 import와 사용처를 업데이트합니다.

## 변경사항

- `AlertType` → `AlertVariant` import 변경
- `notify(type: AlertType, ...)` → `notify(variant: AlertVariant, ...)`
- `Notifier.toast({ type: ... })` → `Notifier.toast({ variant: ... })`

## 관련

- 업스트림 PR: https://github.com/iyulab/node-components/pull/11

## 테스트 계획

- [ ] `npx tsc --noEmit` 타입 체크 성공
- [ ] `app.success()`, `app.error()` 등 알림 메서드 정상 동작 확인