### PR TITLE
fix: SidebarLayout update-in-update anti-pattern 제거

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@iyulab/modern-app",
   "description": "web-framework by iyulab based on lit-element",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "keywords": [
     "iyulab",
     "web-framework",

--- a/src/layouts/SidebarLayout.ts
+++ b/src/layouts/SidebarLayout.ts
@@ -87,8 +87,8 @@ export class SidebarLayout extends StyledElement<SidebarParts> {
     super.disconnectedCallback();
   }
 
-  protected updated(changedProperties: PropertyValues): void {
-    super.updated(changedProperties);
+  protected willUpdate(changedProperties: PropertyValues): void {
+    super.willUpdate(changedProperties);
 
     if (changedProperties.has('config')) {
       this.styles = this.config?.styles;


### PR DESCRIPTION
## Summary
- `SidebarLayout.updated()`에서 `this.styles` reactive property 설정 → Lit 재업데이트 경고 발생
- `updated()` → `willUpdate()`로 이동하여 동일 렌더링 사이클 내 처리
- patch version bump: 0.3.1 → 0.3.2

## Root Cause
`SidebarLayout.updated()` 내에서 `this.styles = this.config?.styles` 설정 시, 부모 `StyledElement.updated()`가 `styles` 변경을 감지하여 새 업데이트를 스케줄링. `willUpdate()`에서 설정하면 render 전에 반영되어 단일 사이클로 완료.

## Test plan
- [ ] `u-sidebar-layout` 사용하는 페이지 로드 후 콘솔에 "scheduled an update after an update completed" 경고 없음 확인
- [ ] 사이드바 레이아웃 스타일 정상 적용 확인
- [ ] 반응형 모드 전환 (default/slim/modal/mobile) 정상 동작 확인

ref: https://lit.dev/msg/change-in-update